### PR TITLE
Deny access to local subnets as well (not only 127.0.0.0/8)

### DIFF
--- a/dante/files/conf/dante.conf
+++ b/dante/files/conf/dante.conf
@@ -28,6 +28,22 @@ socks block {
     log: error
 }
 
+# deny access to private networks
+socks block {
+    from: 0.0.0.0/0 to: 10.0.0.0/8
+    log: error
+}
+
+socks block {
+    from: 0.0.0.0/0 to: 172.16.0.0/12
+    log: error
+}
+
+socks block {
+    from: 0.0.0.0/0 to: 192.168.0.0/16
+    log: error
+}
+
 # deny binding
 socks block {
     from: 0.0.0.0/0 to: 0.0.0.0/0

--- a/dante/files/conf/dante6.conf
+++ b/dante/files/conf/dante6.conf
@@ -33,6 +33,22 @@ socks block {
     log: error
 }
 
+# deny access to private networks
+socks block {
+    from: 0.0.0.0/0 to: 10.0.0.0/8
+    log: error
+}
+
+socks block {
+    from: 0.0.0.0/0 to: 172.16.0.0/12
+    log: error
+}
+
+socks block {
+    from: 0.0.0.0/0 to: 192.168.0.0/16
+    log: error
+}
+
 # deny binding
 socks block {
     from: 0/0 to: 0/0
@@ -143,4 +159,3 @@ socks block {
     from: ::/0 to: ::/0
     log: error
 }
-


### PR DESCRIPTION
That would be great in terms of security if you're also hosting other VMs or projects your proxy users shouldn't be able to access directly.