### PR TITLE
update SHA256 digest

### DIFF
--- a/dante/Dockerfile
+++ b/dante/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="<schors@gmail.com>"
 
 ENV DANTE_VER 1.4.2
 ENV DANTE_URL https://www.inet.no/dante/files/dante-$DANTE_VER.tar.gz
-ENV DANTE_SHA baa25750633a7f9f37467ee43afdf7a95c80274394eddd7dcd4e1542aa75caad
+ENV DANTE_SHA 4c97cff23e5c9b00ca1ec8a95ab22972813921d7fbf60fc453e3e06382fc38a7
 ENV DANTE_FILE dante.tar.gz
 ENV DANTE_TEMP dante
 ENV DANTE_DEPS linux-pam-dev curl gcc g++ make


### PR DESCRIPTION
> 2018-05-17: Dante 1.4.2 NEWS file updated. New source file SHA256 digest: 4c97cff23e5c9b00ca1ec8a95ab22972813921d7fbf60fc453e3e06382fc38a7. No code changes. Please use new version.
[https://www.inet.no/dante/](url)